### PR TITLE
move macro's index variable; declare coroutine locals as volatile

### DIFF
--- a/Libraries/Coroutines/Coroutines.h
+++ b/Libraries/Coroutines/Coroutines.h
@@ -204,12 +204,12 @@
 #define COROUTINE_CONTEXT(coroutine)                            \
 Coroutine& coroutine)                                           \
 {                                                               \
+    byte COROUTINE_localIndex = 0;                              \
     CoroutineImpl& COROUTINE_ctx = (CoroutineImpl&) coroutine;  \
     (void) coroutine;                                           \
     if (true
 
 #define COROUTINE_LOCAL(type, name)                                                        \
-    byte COROUTINE_localIndex = 0;                                                         \
     if (COROUTINE_ctx.jumpLocation == 0 && !COROUTINE_ctx.looping)                         \
     {                                                                                      \
         assert(COROUTINE_ctx.numSavedLocals >= CoroutineImpl::MaxLocals,                   \

--- a/Libraries/Coroutines/Coroutines.h
+++ b/Libraries/Coroutines/Coroutines.h
@@ -220,7 +220,7 @@ Coroutine& coroutine)                                           \
     }                                                                                      \
     else                                                                                   \
         COROUTINE_localIndex = COROUTINE_ctx.numRecoveredLocals++;                         \
-    volatile type& name = *((type*) COROUTINE_ctx.savedLocals[COROUTINE_localIndex]);
+    type& name = *((type*) COROUTINE_ctx.savedLocals[COROUTINE_localIndex]);
 
 #define BEGIN_COROUTINE                                             \
     trace(P("Entering coroutine #%hhu ('%s') at %lu ms"),           \

--- a/Libraries/Coroutines/Coroutines.h
+++ b/Libraries/Coroutines/Coroutines.h
@@ -220,7 +220,7 @@ Coroutine& coroutine)                                           \
     }                                                                                      \
     else                                                                                   \
         COROUTINE_localIndex = COROUTINE_ctx.numRecoveredLocals++;                         \
-    type& name = *((type*) COROUTINE_ctx.savedLocals[COROUTINE_localIndex]);
+    volatile type& name = *((type*) COROUTINE_ctx.savedLocals[COROUTINE_localIndex]);
 
 #define BEGIN_COROUTINE                                             \
     trace(P("Entering coroutine #%hhu ('%s') at %lu ms"),           \


### PR DESCRIPTION
- When declaring more than one `COROUTINE_LOCAL` variable within a `COROUTINE_CONTEXT` the compiler complains that the variable `COROUTINE_localIndex` has already been defined.

XXXX REVERTED: By declaring coroutine local variables as `volatile` we instruct the compiler to use RAM to store the addresses, instead of registers- this can prevent race conditions which may cause crashes.XXXX
